### PR TITLE
Requirements: remove python2 only dependencies 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ netifaces==0.10.9
 netaddr==0.7.19
 dhcplib==0.1.1
 scapy_http==1.8.2
-configparser==4.0.2
 tabulate==0.8.5
 beautifultable==0.8.0
 urwid==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 netifaces==0.10.9
 netaddr==0.7.19
 dhcplib==0.1.1
-ipaddress==1.0.22
 scapy_http==1.8.2
 configparser==4.0.2
 tabulate==0.8.5


### PR DESCRIPTION
https://pypi.org/project/ipaddress/
Port of the 3.3+ ipaddress module to 2.6, 2.7, 3.2