### PR TITLE
add docker compose to manage volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ RUN python3.7 -m pip install pip
 RUN python3.7 -m pip install pyqt5==5.14
 RUN python3.7 -m pip install -r requirements.txt 
 RUN python3.7 setup.py install
-CMD /usr/local/bin/wifipumpkin3 -m docker
-
+#CMD /usr/local/bin/wifipumpkin3 -m docker
+WORKDIR /root/.config/wifipumpkin3
+CMD /usr/local/bin/wifipumpkin3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+services:
+  wifipumpkin3:
+        build:
+                context: .
+        privileged: true
+        network_mode: "host"
+        volumes:
+                - type: bind
+                  source: ./scripts
+                  target: /root/.config/wifipumpkin3/scripts
+                - type: bind
+                  source: ./logs
+                  target: /root/.config/wifipumpkin3/logs
+                - type: bind
+                  source: ./config
+                  target: /root/.config/wifipumpkin3/config

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ dnspython==1.16.0
 Flask==1.1.1
 requests>=2.18.4
 beautifulsoup4>=4.9.1
+asn1crypto>=1.0.0


### PR DESCRIPTION
Here is the summary of the pull request:

#### docker-compose.yml file added to the project

To build the image just run
`$ docker-compose build wifipumpkin3`
To run a container
`$ sudo docker-compose run wifipumpkin3 wifipumpkin3`
To run a container with a pulp file
`$ sudo docker-compose run wifipumpkin3 wifipumpkin3 --pulp scripts/demo.pulp`

#### Modify Dockerfile

Change the workdir to /root/.config/wifipumpkin3 to find the scripts folder
Comment out the wifipumpkin3 execution in docker wirelessmode. This option is not used following the current documentation and it gets an error everytime I try to run it

```
$ sudo docker-compose run wifipumpkin3 wifipumpkin3 -m docker
Traceback (most recent call last):
  File "/usr/local/bin/wifipumpkin3", line 11, in <module>
    load_entry_point('wifipumpkin3==1.0.5', 'console_scripts', 'wifipumpkin3')()
  File "/usr/local/lib/python3.7/dist-packages/wifipumpkin3-1.0.5-py3.7.egg/wifipumpkin3/__main__.py", line 93, in main
    parser_args_func(parse_args)
  File "/usr/local/lib/python3.7/dist-packages/wifipumpkin3-1.0.5-py3.7.egg/wifipumpkin3/__main__.py", line 27, in parser_args_func
    if parse_args.wireless_mode in conf.get_all_childname("ap_mode"):
  File "/usr/local/lib/python3.7/dist-packages/scapy/config.py", line 660, in __getattr__
    return object.__getattr__(self, attr)
AttributeError: type object 'object' has no attribute '__getattr__'
```

#### Modify requirements.txt

I added the asn1crypto version to avoid this error

`Installed /usr/local/lib/python3.7/dist-packages/wifipumpkin3-1.0.5-py3.7.egg
Processing dependencies for wifipumpkin3==1.0.5
error: asn1crypto 0.24.0 is installed but asn1crypto>=1.0.0 is required by {'oscrypto'}`

I didn't have this problem building the 1.0.5 wifipumpkin3 version