### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/wifipumpkin3/core/packets/dnsserver.py
+++ b/wifipumpkin3/core/packets/dnsserver.py
@@ -278,7 +278,7 @@ class DNSServerThread(QThread):
         self.tcp_server.start_thread()
 
         try:
-            while self.udp_server.isAlive():
+            while self.udp_server.is_alive():
                 sleep(1)
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
Fixes #68 . `is_alive` is present in both python 2.7 and Python 3 for `isAlive`.