### PR TITLE
Fix accesspoint typos

### DIFF
--- a/helps/help_set_command.txt
+++ b/helps/help_set_command.txt
@@ -1,10 +1,10 @@
 set AP variables:
  
  Usage: set [variable] [value]
- param variable: set variables accesspoit [ssid, bssid, interface, security, channel]
+ param variable: set variables accesspoint [ssid, bssid, interface, security, channel]
 
  Description:
-    Change variables rogue accesspoit attack
+    Change variables rogue accesspoint attack
 
 Referencies:
    https://wifipumpkin3.github.io/docs/getting-started#core-commands


### PR DESCRIPTION
The word "accesspoint" was originally missing the "n".