### PR TITLE
Fix locale error when running inside a Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - fixed cli error when resquest restAPI plugins and proxies
 - fixed restApi error when get exceptions http request
 - fixed wirelesscontroller not started into restAPI mode
+- fixed locale error in docker container
 
 ## [Released]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ netifaces>=0.10.9
 netaddr>=0.7.19
 dhcplib==0.1.1
 tabulate>=0.8.5
-urwid==2.1.1
+urwid==2.1.2
 termcolor>=1.1.0
 twisted==19.7.0
 PyQt5>=5.14


### PR DESCRIPTION
Update urwid to 2.1.2.
This fixes #129.